### PR TITLE
Use new constructor signature

### DIFF
--- a/receiver/observiqreceiver/factory.go
+++ b/receiver/observiqreceiver/factory.go
@@ -57,10 +57,19 @@ func (f *Factory) CreateLogsReceiver(
 	cfg configmodels.Receiver,
 	nextConsumer consumer.LogsConsumer,
 ) (component.LogsReceiver, error) {
+
 	obsConfig := cfg.(*Config)
 	logsChan := make(chan *obsentry.Entry)
-	logAgent := observiq.NewLogAgent(&observiq.Config{Pipeline: obsConfig.Pipeline}, params.Logger.Sugar(), obsConfig.PluginsDir, obsConfig.OffsetsFile).
-		WithBuildParameter(logsChannelID, logsChan)
+	buildParams := map[string]interface{}{logsChannelID: logsChan}
+	logAgent, err := observiq.NewLogAgent(
+		&observiq.Config{Pipeline: obsConfig.Pipeline},
+		params.Logger.Sugar(),
+		obsConfig.PluginsDir,
+		obsConfig.OffsetsFile,
+		buildParams)
+	if err != nil {
+		return nil, err
+	}
 
 	return &observiqReceiver{
 		agent:    logAgent,

--- a/receiver/observiqreceiver/go.mod
+++ b/receiver/observiqreceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/observ
 go 1.14
 
 require (
-	github.com/observiq/carbon v0.9.9
+	github.com/observiq/carbon v0.9.10-0.20200818151630-e9e0bd2fcd7d
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.8.1-0.20200815205113-8e5c6065eb0e

--- a/receiver/observiqreceiver/go.sum
+++ b/receiver/observiqreceiver/go.sum
@@ -527,6 +527,7 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/flux v0.65.0/go.mod h1:BwN2XG2lMszOoquQaFdPET8FRQfrXiZsWmcMO9rkaVY=
 github.com/influxdata/go-syslog/v3 v3.0.0 h1:jichmjSZlYK0VMmlz+k4WeOQd7z745YLsvGMqwtYt4I=
@@ -705,6 +706,8 @@ github.com/observiq/carbon v0.9.7 h1:jurX9OqkTU71RZHELQXg66lOdkKDNu1BDw6wkrgdhT0
 github.com/observiq/carbon v0.9.7/go.mod h1:rxxa0rqG3+8P9EQsLvjkb9l3CX5iH7aiqDKzO9Y0H7s=
 github.com/observiq/carbon v0.9.9 h1:1G4yfsAUjsAXv8S+XhZcZllFeaI4bLTJsDE1jQE6PNY=
 github.com/observiq/carbon v0.9.9/go.mod h1:CTPUw59WPRIpjv2lHvi3Xa8eXq1WH+UAOX08Nu1v8LU=
+github.com/observiq/carbon v0.9.10-0.20200818151630-e9e0bd2fcd7d h1:to1CMNffttQsZH200Ml2ek0gE37MQBDlg8c7XdUls18=
+github.com/observiq/carbon v0.9.10-0.20200818151630-e9e0bd2fcd7d/go.mod h1:CTPUw59WPRIpjv2lHvi3Xa8eXq1WH+UAOX08Nu1v8LU=
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
 github.com/observiq/go-syslog/v3 v3.0.2 h1:vaeINFErM/E3cKE2Ot1FAhhGq5mv7uGBOzjnGL3qhbY=


### PR DESCRIPTION
I tested this along with the Carbon PR by adding the following line to my `go.mod` file:
```
replace github.com/observiq/carbon => ../carbon
```