### PR TITLE
try and match bpagent timeouts for larger scaled payloads

### DIFF
--- a/exporter/observiqexporter/client.go
+++ b/exporter/observiqexporter/client.go
@@ -202,9 +202,9 @@ func buildClient(config *Config, logger *zap.Logger, buildInfo component.BuildIn
 			Transport: &http.Transport{
 				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: tlsCfg,
-				Dial: (&net.Dialer{
+				DialContext: (&net.Dialer{
 					Timeout: 10 * time.Second,
-				}).Dial,
+				}).DialContext,
 				TLSHandshakeTimeout: 10 * time.Second,
 			},
 		},

--- a/exporter/observiqexporter/client.go
+++ b/exporter/observiqexporter/client.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -201,6 +202,10 @@ func buildClient(config *Config, logger *zap.Logger, buildInfo component.BuildIn
 			Transport: &http.Transport{
 				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: tlsCfg,
+				Dial: (&net.Dialer{
+					Timeout: 10 * time.Second,
+				}).Dial,
+				TLSHandshakeTimeout: 10 * time.Second,
 			},
 		},
 		logger:       logger,

--- a/exporter/observiqexporter/factory.go
+++ b/exporter/observiqexporter/factory.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	typeStr            = "observiq"
-	defaultHTTPTimeout = 10 * time.Second
+	defaultHTTPTimeout = 20 * time.Second
 	defaultEndpoint    = "https://nozzle.app.observiq.com/v1/add"
 )
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Noticing we are getting this error trying to do large payloads:

```
{"level":"info","ts":"2021-09-29T19:02:27.103Z","caller":"exporterhelper/queued_retry.go:325","msg":"Exporting failed. Will retry the request after interval.","kind":"exporter","name":"observiq","error":"client failed to submit request to observIQ. Review the underlying error message to troubleshoot the issue underlying_error: Post \"https://nozzle.app.observiq.com/v1/add\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","interval":"3.515934383s"}
```


I talked to jsirianni about this and it appears that we have encountered something similar before but just trying to match timeout behavior for https://github.com/BlueMedora/bpagent/blob/master/pkg/logagent/output_cabin.go


**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>