### PR TITLE
fix: don't collect system.cpu.utilization per-cpu

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -60,7 +60,8 @@ func (s *scraper) start(ctx context.Context, _ component.Host) error {
 func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	ctx = context.WithValue(ctx, common.EnvKey, s.config.EnvMap)
 	now := pcommon.NewTimestampFromTime(s.now())
-	cpuTimes, err := s.times(ctx, true /*percpu=*/)
+	// set percpu=false to support Windows 7
+	cpuTimes, err := s.times(ctx, false /*percpu=*/)
 	if err != nil {
 		return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -342,7 +342,10 @@ func assertCPUMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon
 	if startTime != 0 {
 		internal.AssertSumMetricStartTimeEquals(t, metric, startTime)
 	}
-	assert.GreaterOrEqual(t, metric.Sum().DataPoints().Len(), 4*runtime.NumCPU())
+	cpuUtilizationStates := []string{"user", "system", "idle", "interrupt"}
+
+	// CPU time is not per-CPU, just assert we collected at least one metric for each state
+	assert.GreaterOrEqual(t, metric.Sum().DataPoints().Len(), len(cpuUtilizationStates))
 	internal.AssertSumMetricHasAttribute(t, metric, 0, "cpu")
 	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "state",
 		pcommon.NewValueStr(metadata.AttributeStateUser.String()))


### PR DESCRIPTION
- In `hostmetricsreceiver`, set `percpu=false` when calling `cpu.TimesWithContext`.
  - For Windows, this uses [GetSystemTimes](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getsystemtimes) to get System-wide counters for CPU idle/system/user time.
  - This will create a single `system.cpu.utilization` metric with `cpu` attribute "cpu-total", which I think is suitable for our use case here