### PR TITLE
[exporter/googlesecops] Promote Google SecOps exporter to alpha

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -88,6 +88,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.145.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter v0.145.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.145.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlesecopsexporter v0.145.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter v0.145.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter v0.145.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.145.0

--- a/exporter/googlesecopsexporter/internal/metadata/generated_status.go
+++ b/exporter/googlesecopsexporter/internal/metadata/generated_status.go
@@ -12,5 +12,5 @@ var (
 )
 
 const (
-	LogsStability = component.StabilityLevelDevelopment
+	LogsStability = component.StabilityLevelAlpha
 )

--- a/exporter/googlesecopsexporter/metadata.yaml
+++ b/exporter/googlesecopsexporter/metadata.yaml
@@ -3,7 +3,8 @@ type: googlesecops
 status:
   class: exporter
   stability:
-    development: [logs]
+    alpha: [logs]
+  distributions: [contrib]
   codeowners:
     active: [braydonk, dpaasman00, mrsillydog]
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -55,6 +55,7 @@ module-sets:
       - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
       - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter
       - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlesecopsexporter
       - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter
       - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
       - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter


### PR DESCRIPTION
## Summary

Promote the Google SecOps exporter from development to alpha stability and integrate it into the contrib collector build.

This is **PR 3 of 3** in a stacked PR series:
- **PR1 ([#4722](https://github.com/observIQ/opentelemetry-collector-contrib/pull/4722)):** Component structure — metadata, config, factory, generated files
- **PR2 ([#4723](https://github.com/observIQ/opentelemetry-collector-contrib/pull/4723)):** Implementation — exporter logic, protobuf definitions, tests
- **PR3 (this PR):** Alpha promotion — stability bump, add to builder-config and versions.yaml

### Changes

- `metadata.yaml` — stability bumped from `development` to `alpha`; added `distributions: [contrib]`
- `internal/metadata/generated_status.go` — regenerated to reflect alpha stability
- `cmd/otelcontribcol/builder-config.yaml` — add `googlesecopsexporter` to the contrib collector build
- `versions.yaml` — add `googlesecopsexporter` to module version tracking