### PR TITLE
fix[azureblobreceiver]: Blob client always deletes regardless of read success

### DIFF
--- a/receiver/azureblobreceiver/blob_eventhandler.go
+++ b/receiver/azureblobreceiver/blob_eventhandler.go
@@ -74,19 +74,28 @@ func (p *blobEventHandler) processContainer(ctx context.Context, containerName s
 	}
 
 	for _, blobName := range blobs {
-		if ctx.Err() != nil {
-			return
-		}
+		p.processBlob(ctx, containerName, blobName, consume)
+	}
+}
 
-		blobData, err := p.blobClient.readBlob(ctx, containerName, blobName)
-		if err != nil {
-			p.logger.Error("failed to read blob", zap.String("container", containerName), zap.String("blob", blobName), zap.Error(err))
-			continue
-		}
+func (p *blobEventHandler) processBlob(ctx context.Context, containerName string, blobName string, consume func(context.Context, []byte) error) {
+	if ctx.Err() != nil {
+		return
+	}
 
-		if err := consume(ctx, blobData.Bytes()); err != nil {
-			p.logger.Error("failed to consume blob data", zap.String("container", containerName), zap.String("blob", blobName), zap.Error(err))
-		}
+	blobData, err := p.blobClient.readBlob(ctx, containerName, blobName)
+	if err != nil {
+		p.logger.Error("failed to read blob", zap.String("container", containerName), zap.String("blob", blobName), zap.Error(err))
+		return
+	}
+
+	if err := consume(ctx, blobData.Bytes()); err != nil {
+		p.logger.Error("failed to consume blob data", zap.String("container", containerName), zap.String("blob", blobName), zap.Error(err))
+		return
+	}
+
+	if err := p.blobClient.deleteBlob(ctx, containerName, blobName); err != nil {
+		p.logger.Error("failed to delete blob", zap.Error(err))
 	}
 }
 

--- a/receiver/azureblobreceiver/blob_eventhandler.go
+++ b/receiver/azureblobreceiver/blob_eventhandler.go
@@ -78,7 +78,7 @@ func (p *blobEventHandler) processContainer(ctx context.Context, containerName s
 	}
 }
 
-func (p *blobEventHandler) processBlob(ctx context.Context, containerName string, blobName string, consume func(context.Context, []byte) error) {
+func (p *blobEventHandler) processBlob(ctx context.Context, containerName, blobName string, consume func(context.Context, []byte) error) {
 	if ctx.Err() != nil {
 		return
 	}

--- a/receiver/azureblobreceiver/blob_eventhandler_test.go
+++ b/receiver/azureblobreceiver/blob_eventhandler_test.go
@@ -5,6 +5,8 @@ package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -54,6 +56,7 @@ func TestBlobEventHandler_ProcessContainers(t *testing.T) {
 	blobClient.On("listBlobs", mock.Anything, logsContainerName).Return([]string{"log1.json", "log2.json"}, nil)
 	blobClient.On("listBlobs", mock.Anything, tracesContainerName).Return([]string{"trace1.json"}, nil)
 	blobClient.On("readBlob", mock.Anything, mock.Anything, mock.Anything).Return(bytes.NewBufferString("{}"), nil)
+	blobClient.On("deleteBlob", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	handler := getBlobEventHandler(t, blobClient)
 
@@ -67,6 +70,62 @@ func TestBlobEventHandler_ProcessContainers(t *testing.T) {
 	logsConsumer.AssertNumberOfCalls(t, "consumeLogsJSON", 2)
 	tracesConsumer.AssertNumberOfCalls(t, "consumeTracesJSON", 1)
 	blobClient.AssertNumberOfCalls(t, "readBlob", 3)
+	blobClient.AssertNumberOfCalls(t, "deleteBlob", 3)
+}
+
+func TestBlobEventHandler_ProcessBlob_DeletesAfterSuccessfulConsume(t *testing.T) {
+	blobClient := newMockBlobClient()
+	handler := getBlobEventHandler(t, blobClient)
+	handler.setLogsDataConsumer(newMockLogsDataConsumer())
+
+	handler.processBlob(t.Context(), logsContainerName, "log1.json", func(_ context.Context, _ []byte) error {
+		return nil
+	})
+
+	blobClient.AssertCalled(t, "readBlob", mock.Anything, logsContainerName, "log1.json")
+	blobClient.AssertCalled(t, "deleteBlob", mock.Anything, logsContainerName, "log1.json")
+}
+
+func TestBlobEventHandler_ProcessBlob_DoesNotDeleteOnReadError(t *testing.T) {
+	blobClient := &mockBlobClient{}
+	blobClient.On("readBlob", mock.Anything, mock.Anything, mock.Anything).Return((*bytes.Buffer)(nil), errors.New("read failed"))
+
+	handler := getBlobEventHandler(t, blobClient)
+	handler.setLogsDataConsumer(newMockLogsDataConsumer())
+
+	handler.processBlob(t.Context(), logsContainerName, "log1.json", func(_ context.Context, _ []byte) error {
+		return nil
+	})
+
+	blobClient.AssertCalled(t, "readBlob", mock.Anything, logsContainerName, "log1.json")
+	blobClient.AssertNotCalled(t, "deleteBlob", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestBlobEventHandler_ProcessBlob_DoesNotDeleteOnConsumeError(t *testing.T) {
+	blobClient := newMockBlobClient()
+	handler := getBlobEventHandler(t, blobClient)
+
+	handler.processBlob(t.Context(), logsContainerName, "log1.json", func(_ context.Context, _ []byte) error {
+		return errors.New("consume failed")
+	})
+
+	blobClient.AssertCalled(t, "readBlob", mock.Anything, logsContainerName, "log1.json")
+	blobClient.AssertNotCalled(t, "deleteBlob", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestBlobEventHandler_ProcessBlob_DoesNotDeleteOnCancelledContext(t *testing.T) {
+	blobClient := newMockBlobClient()
+	handler := getBlobEventHandler(t, blobClient)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	handler.processBlob(ctx, logsContainerName, "log1.json", func(_ context.Context, _ []byte) error {
+		return nil
+	})
+
+	blobClient.AssertNotCalled(t, "readBlob", mock.Anything, mock.Anything, mock.Anything)
+	blobClient.AssertNotCalled(t, "deleteBlob", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestBlobEventHandler_ProcessContainersWithNoConsumers(t *testing.T) {

--- a/receiver/azureblobreceiver/blobclient.go
+++ b/receiver/azureblobreceiver/blobclient.go
@@ -43,9 +43,7 @@ func (bc *azureBlobClient) listBlobs(ctx context.Context, containerName string) 
 }
 
 func (bc *azureBlobClient) readBlob(ctx context.Context, containerName, blobName string) (*bytes.Buffer, error) {
-	var err error
-	var get azblob.DownloadStreamResponse
-	get, err = bc.serviceClient.DownloadStream(ctx, containerName, blobName, nil)
+	get, err := bc.serviceClient.DownloadStream(ctx, containerName, blobName, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/azureblobreceiver/blobclient.go
+++ b/receiver/azureblobreceiver/blobclient.go
@@ -15,6 +15,7 @@ import (
 type blobClient interface {
 	readBlob(ctx context.Context, containerName, blobName string) (*bytes.Buffer, error)
 	listBlobs(ctx context.Context, containerName string) ([]string, error)
+	deleteBlob(ctx context.Context, containerName, blobName string) error
 }
 
 type azureBlobClient struct {
@@ -43,16 +44,6 @@ func (bc *azureBlobClient) listBlobs(ctx context.Context, containerName string) 
 
 func (bc *azureBlobClient) readBlob(ctx context.Context, containerName, blobName string) (*bytes.Buffer, error) {
 	var err error
-	defer func() {
-		if err != nil {
-			return
-		}
-		_, blobDeleteErr := bc.serviceClient.DeleteBlob(ctx, containerName, blobName, nil)
-		if blobDeleteErr != nil {
-			bc.logger.Error("failed to delete blob", zap.Error(blobDeleteErr))
-		}
-	}()
-
 	var get azblob.DownloadStreamResponse
 	get, err = bc.serviceClient.DownloadStream(ctx, containerName, blobName, nil)
 	if err != nil {
@@ -66,6 +57,11 @@ func (bc *azureBlobClient) readBlob(ctx context.Context, containerName, blobName
 	_, err = downloadedData.ReadFrom(retryReader)
 
 	return downloadedData, err
+}
+
+func (bc *azureBlobClient) deleteBlob(ctx context.Context, containerName, blobName string) error {
+	_, err := bc.serviceClient.DeleteBlob(ctx, containerName, blobName, nil)
+	return err
 }
 
 func newBlobClientFromConnectionString(connectionString string, logger *zap.Logger) (*azureBlobClient, error) {

--- a/receiver/azureblobreceiver/blobclient.go
+++ b/receiver/azureblobreceiver/blobclient.go
@@ -41,26 +41,30 @@ func (bc *azureBlobClient) listBlobs(ctx context.Context, containerName string) 
 	return blobs, nil
 }
 
-func (bc *azureBlobClient) readBlob(ctx context.Context, containerName, blobName string) (*bytes.Buffer, error) {
+func (bc *azureBlobClient) readBlob(ctx context.Context, containerName, blobName string) (downloadedData *bytes.Buffer, err error) {
 	defer func() {
+		if err != nil {
+			return
+		}
 		_, blobDeleteErr := bc.serviceClient.DeleteBlob(ctx, containerName, blobName, nil)
 		if blobDeleteErr != nil {
 			bc.logger.Error("failed to delete blob", zap.Error(blobDeleteErr))
 		}
 	}()
 
-	get, err := bc.serviceClient.DownloadStream(ctx, containerName, blobName, nil)
-	if err != nil {
-		return nil, err
+	get, getErr := bc.serviceClient.DownloadStream(ctx, containerName, blobName, nil)
+	if getErr != nil {
+		err = getErr
+		return
 	}
 
-	downloadedData := &bytes.Buffer{}
+	downloadedData = &bytes.Buffer{}
 	retryReader := get.NewRetryReader(ctx, &azblob.RetryReaderOptions{})
 	defer retryReader.Close()
 
 	_, err = downloadedData.ReadFrom(retryReader)
 
-	return downloadedData, err
+	return
 }
 
 func newBlobClientFromConnectionString(connectionString string, logger *zap.Logger) (*azureBlobClient, error) {

--- a/receiver/azureblobreceiver/blobclient.go
+++ b/receiver/azureblobreceiver/blobclient.go
@@ -41,7 +41,8 @@ func (bc *azureBlobClient) listBlobs(ctx context.Context, containerName string) 
 	return blobs, nil
 }
 
-func (bc *azureBlobClient) readBlob(ctx context.Context, containerName, blobName string) (downloadedData *bytes.Buffer, err error) {
+func (bc *azureBlobClient) readBlob(ctx context.Context, containerName, blobName string) (*bytes.Buffer, error) {
+	var err error
 	defer func() {
 		if err != nil {
 			return
@@ -52,19 +53,19 @@ func (bc *azureBlobClient) readBlob(ctx context.Context, containerName, blobName
 		}
 	}()
 
-	get, getErr := bc.serviceClient.DownloadStream(ctx, containerName, blobName, nil)
-	if getErr != nil {
-		err = getErr
-		return
+	var get azblob.DownloadStreamResponse
+	get, err = bc.serviceClient.DownloadStream(ctx, containerName, blobName, nil)
+	if err != nil {
+		return nil, err
 	}
 
-	downloadedData = &bytes.Buffer{}
+	downloadedData := &bytes.Buffer{}
 	retryReader := get.NewRetryReader(ctx, &azblob.RetryReaderOptions{})
 	defer retryReader.Close()
 
 	_, err = downloadedData.ReadFrom(retryReader)
 
-	return
+	return downloadedData, err
 }
 
 func newBlobClientFromConnectionString(connectionString string, logger *zap.Logger) (*azureBlobClient, error) {

--- a/receiver/azureblobreceiver/eventhub_eventhandler.go
+++ b/receiver/azureblobreceiver/eventhub_eventhandler.go
@@ -162,6 +162,7 @@ func (p *eventHubEventHandler) processBlobCreatedEventType(ctx context.Context, 
 		}
 	default:
 		p.logger.Debug("Unknown container name", zap.String("containerName", containerName))
+		return nil
 	}
 
 	if err := p.blobClient.deleteBlob(ctx, containerName, blobName); err != nil {

--- a/receiver/azureblobreceiver/eventhub_eventhandler.go
+++ b/receiver/azureblobreceiver/eventhub_eventhandler.go
@@ -139,26 +139,34 @@ func (p *eventHubEventHandler) newMessageHandler(ctx context.Context, event *aze
 	blobName := strings.Split(subject, "blobs/")[1]
 
 	if eventType == blobCreatedEventType {
-		blobData, err := p.blobClient.readBlob(ctx, containerName, blobName)
-		if err != nil {
-			return err
-		}
-		switch containerName {
-		case p.logsContainerName:
-			err = p.logsDataConsumer.consumeLogsJSON(ctx, blobData.Bytes())
-			if err != nil {
-				return err
-			}
-		case p.tracesContainerName:
-			err = p.tracesDataConsumer.consumeTracesJSON(ctx, blobData.Bytes())
-			if err != nil {
-				return err
-			}
-		default:
-			p.logger.Debug("Unknown container name", zap.String("containerName", containerName))
-		}
+		return p.processBlobCreatedEventType(ctx, containerName, blobName)
 	}
 
+	return nil
+}
+
+func (p *eventHubEventHandler) processBlobCreatedEventType(ctx context.Context, containerName, blobName string) error {
+	blobData, err := p.blobClient.readBlob(ctx, containerName, blobName)
+	if err != nil {
+		return err
+	}
+
+	switch containerName {
+	case p.logsContainerName:
+		if err := p.logsDataConsumer.consumeLogsJSON(ctx, blobData.Bytes()); err != nil {
+			return err
+		}
+	case p.tracesContainerName:
+		if err := p.tracesDataConsumer.consumeTracesJSON(ctx, blobData.Bytes()); err != nil {
+			return err
+		}
+	default:
+		p.logger.Debug("Unknown container name", zap.String("containerName", containerName))
+	}
+
+	if err := p.blobClient.deleteBlob(ctx, containerName, blobName); err != nil {
+		p.logger.Error("failed to delete blob", zap.Error(err))
+	}
 	return nil
 }
 

--- a/receiver/azureblobreceiver/eventhub_eventhandler_test.go
+++ b/receiver/azureblobreceiver/eventhub_eventhandler_test.go
@@ -4,10 +4,13 @@
 package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"
 
 import (
+	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
@@ -49,6 +52,68 @@ func TestNewEventHubMessageHandler(t *testing.T) {
 	logsDataConsumer.AssertNumberOfCalls(t, "consumeLogsJSON", 1)
 	tracesDataConsumer.AssertNumberOfCalls(t, "consumeTracesJSON", 1)
 	blobClient.AssertNumberOfCalls(t, "readBlob", 2)
+	blobClient.AssertNumberOfCalls(t, "deleteBlob", 2)
+}
+
+func TestEventHubEventHandler_ProcessBlobCreated_DoesNotDeleteOnReadError(t *testing.T) {
+	blobClient := &mockBlobClient{}
+	blobClient.On("readBlob", mock.Anything, mock.Anything, mock.Anything).Return((*bytes.Buffer)(nil), errors.New("read failed"))
+
+	handler := getEventHubEventHandler(t, blobClient)
+	handler.setLogsDataConsumer(newMockLogsDataConsumer())
+	handler.setTracesDataConsumer(newMockTracesDataConsumer())
+
+	err := handler.processBlobCreatedEventType(t.Context(), logsContainerName, "logs-1")
+	require.Error(t, err)
+
+	blobClient.AssertCalled(t, "readBlob", mock.Anything, logsContainerName, "logs-1")
+	blobClient.AssertNotCalled(t, "deleteBlob", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestEventHubEventHandler_ProcessBlobCreated_DoesNotDeleteOnConsumeError(t *testing.T) {
+	blobClient := newMockBlobClient()
+
+	logsConsumer := &mockLogsDataConsumer{}
+	logsConsumer.On("consumeLogsJSON", mock.Anything, mock.Anything).Return(errors.New("consume failed"))
+
+	handler := getEventHubEventHandler(t, blobClient)
+	handler.setLogsDataConsumer(logsConsumer)
+	handler.setTracesDataConsumer(newMockTracesDataConsumer())
+
+	err := handler.processBlobCreatedEventType(t.Context(), logsContainerName, "logs-1")
+	require.Error(t, err)
+
+	blobClient.AssertCalled(t, "readBlob", mock.Anything, logsContainerName, "logs-1")
+	blobClient.AssertNotCalled(t, "deleteBlob", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestEventHubEventHandler_NewMessageHandler_PropagatesConsumeError(t *testing.T) {
+	blobClient := newMockBlobClient()
+
+	logsConsumer := &mockLogsDataConsumer{}
+	logsConsumer.On("consumeLogsJSON", mock.Anything, mock.Anything).Return(errors.New("consume failed"))
+
+	handler := getEventHubEventHandler(t, blobClient)
+	handler.setLogsDataConsumer(logsConsumer)
+	handler.setTracesDataConsumer(newMockTracesDataConsumer())
+
+	err := handler.newMessageHandler(t.Context(), getEventHubEvent(logEventData))
+	require.Error(t, err)
+
+	blobClient.AssertNotCalled(t, "deleteBlob", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestEventHubEventHandler_ProcessBlobCreated_DeletesAfterSuccessfulConsume(t *testing.T) {
+	blobClient := newMockBlobClient()
+	handler := getEventHubEventHandler(t, blobClient)
+	handler.setLogsDataConsumer(newMockLogsDataConsumer())
+	handler.setTracesDataConsumer(newMockTracesDataConsumer())
+
+	err := handler.processBlobCreatedEventType(t.Context(), logsContainerName, "logs-1")
+	require.NoError(t, err)
+
+	blobClient.AssertCalled(t, "readBlob", mock.Anything, logsContainerName, "logs-1")
+	blobClient.AssertCalled(t, "deleteBlob", mock.Anything, logsContainerName, "logs-1")
 }
 
 func getEventHubEvent(eventData []byte) *azeventhubs.ReceivedEventData {

--- a/receiver/azureblobreceiver/mock_blobclient.go
+++ b/receiver/azureblobreceiver/mock_blobclient.go
@@ -55,9 +55,24 @@ func (_m *mockBlobClient) listBlobs(ctx context.Context, containerName string) (
 	return r0, r1
 }
 
+// DeleteBlob provides a mock function with given fields: ctx, containerName, blobName
+func (_m *mockBlobClient) deleteBlob(ctx context.Context, containerName, blobName string) error {
+	ret := _m.Called(ctx, containerName, blobName)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, containerName, blobName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 func newMockBlobClient() *mockBlobClient {
 	blobClient := &mockBlobClient{}
 	blobClient.On("readBlob", mock.Anything, mock.Anything, mock.Anything).Return(&bytes.Buffer{}, nil)
 	blobClient.On("listBlobs", mock.Anything, mock.Anything).Return([]string{}, nil)
+	blobClient.On("deleteBlob", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	return blobClient
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is a fast fix that makes the azure blob receiver only delete the blob if it is read and processed successfully.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
